### PR TITLE
Add response caching to controllers and update CORS

### DIFF
--- a/ApiCurso/Controllers/CategoriasController.cs
+++ b/ApiCurso/Controllers/CategoriasController.cs
@@ -16,6 +16,7 @@ namespace ApiCurso.Controllers
         private readonly IMapper _mapper = mapper;
 
         [AllowAnonymous]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -32,6 +33,7 @@ namespace ApiCurso.Controllers
         }
 
         [AllowAnonymous]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         [HttpGet("{id:int}", Name = "GetCategoria")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/ApiCurso/Controllers/PeliculasController.cs
+++ b/ApiCurso/Controllers/PeliculasController.cs
@@ -67,6 +67,7 @@ namespace ApiCurso.Controllers
         }
 
         [AllowAnonymous]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         [HttpGet("{id:int}", Name = "GetPelicula")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -84,6 +85,7 @@ namespace ApiCurso.Controllers
         }
 
         [AllowAnonymous]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -99,6 +101,7 @@ namespace ApiCurso.Controllers
         }
 
         [AllowAnonymous]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         [HttpGet("GetPeliculasByCategoria/{categoriaId:int}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -117,6 +120,7 @@ namespace ApiCurso.Controllers
         }
 
         [AllowAnonymous]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         [HttpGet("SearchPelicula/{nombre}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/ApiCurso/Controllers/UsuariosController.cs
+++ b/ApiCurso/Controllers/UsuariosController.cs
@@ -20,6 +20,7 @@ namespace ApiCurso.Controllers
 
         // Obtener todos los usuarios
         [HttpGet]
+        [ResponseCache(CacheProfileName = "Default30")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [EnableCors("CorsPolicy")]  //Aplica políticas solo a este endpoint
         public IActionResult GetUsuarios()
@@ -41,6 +42,7 @@ namespace ApiCurso.Controllers
 
         // Obtener un usuario por ID
         [HttpGet("{id:int}", Name = "GetUsuario")]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [EnableCors("CorsPolicy")]  //Aplica políticas solo a este endpoint

--- a/ApiCurso/Program.cs
+++ b/ApiCurso/Program.cs
@@ -3,6 +3,7 @@ using ApiCurso.Mapper;
 using ApiCurso.Repository;
 using ApiCurso.Repository.IRepository;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -14,7 +15,15 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseSqlServer(builder.Configuration.GetConnectionString("SqlConnection")));
 
-builder.Services.AddControllers();
+//Soporte para cache
+builder.Services.AddResponseCaching();
+
+builder.Services.AddControllers(options =>
+{
+    //Cache para todos los endpoints y no tener que agregar el atributo [ResponseCache] en todos los endpoints
+    options.CacheProfiles.Add("Default30", new CacheProfile() { Duration = 30 });
+});
+
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 
@@ -25,7 +34,7 @@ builder.Services.AddSwaggerGen(options =>
     {
         Description = "Autentificación JWT usando el esquema Bearer. \r\n\r\n" +
         "Ingresa la palabra 'Bearer' seguido de un [espacio] y después su token en el campo de abajo.\r\n\r\n" +
-        "Ejemplo: \"Bearer tkopskfkpsldkfpiojukjmoipjk\"",
+        "Ejemplo: \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\"",
         Name = "Authorization",
         In = ParameterLocation.Header,
         Scheme = "Bearer"
@@ -78,7 +87,7 @@ builder.Services.AddCors(builder =>
 {
     builder.AddPolicy("CorsPolicy", options =>
     {
-        options.AllowAnyHeader().WithOrigins("http://localhost:1234");
+        options.AllowAnyHeader().WithOrigins("https://localhost:7174");
     });
 });
 


### PR DESCRIPTION
This commit introduces response caching for endpoints in the `CategoriasController`, `PeliculasController`, and `UsuariosController`, allowing responses to be cached for 60 seconds. A global cache profile named "Default30" is added in `Program.cs`, simplifying caching configuration across all endpoints.