### PR TITLE
Implement API versioning across controllers

### DIFF
--- a/ApiCurso/ApiCurso.csproj
+++ b/ApiCurso/ApiCurso.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.14" />

--- a/ApiCurso/Controllers/UsuariosController.cs
+++ b/ApiCurso/Controllers/UsuariosController.cs
@@ -1,6 +1,7 @@
 ﻿using ApiCurso.Model;
 using ApiCurso.Model.Dto.Usuario;
 using ApiCurso.Repository.IRepository;
+using Asp.Versioning;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
@@ -10,8 +11,9 @@ using System.Net;
 namespace ApiCurso.Controllers
 {
     [Authorize(Roles = "admin")]
-    [Route("api/usuarios")]
+    [Route("api/v{version:apiVersion}/usuarios")]
     [ApiController]
+    [ApiVersionNeutral]
     public class UsuariosController(IUsuarioRepository usuarioRepository, IMapper mapper) : ControllerBase
     {
         private readonly IUsuarioRepository _usuarioRepository = usuarioRepository;

--- a/ApiCurso/Controllers/V1/CategoriasController.cs
+++ b/ApiCurso/Controllers/V1/CategoriasController.cs
@@ -1,15 +1,17 @@
 ﻿using ApiCurso.Model;
 using ApiCurso.Model.Dto.Categoria;
 using ApiCurso.Repository.IRepository;
+using Asp.Versioning;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace ApiCurso.Controllers
+namespace ApiCurso.Controllers.V1
 {
     [Authorize(Roles = "admin")]
-    [Route("api/categorias")]
+    [Route("api/v{version:apiVersion}/categorias")]
     [ApiController]
+    [ApiVersion("1.0", Deprecated = true)]
     public class CategoriasController(ICategoriaRepository categoriaRepository, IMapper mapper) : ControllerBase
     {
         private readonly ICategoriaRepository _categoriaRepository = categoriaRepository;
@@ -151,6 +153,14 @@ namespace ApiCurso.Controllers
             }
 
             return NoContent();
+        }
+
+        [AllowAnonymous]
+        [HttpGet("GetString")]
+        [Obsolete("Este método está obsoleto. Use el endpoint GetString en la versión 2.0.")]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
         }
     }
 }

--- a/ApiCurso/Controllers/V1/PeliculasController.cs
+++ b/ApiCurso/Controllers/V1/PeliculasController.cs
@@ -1,15 +1,17 @@
 ﻿using ApiCurso.Model;
 using ApiCurso.Model.Dto.Pelicula;
 using ApiCurso.Repository.IRepository;
+using Asp.Versioning;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace ApiCurso.Controllers
+namespace ApiCurso.Controllers.V1
 {
     [Authorize(Roles = "admin")]
-    [Route("api/peliculas")]
+    [Route("api/v{version:apiVersion}/peliculas")]
     [ApiController]
+    [ApiVersion("1.0")]
     public class PeliculasController(IPeliculaRepository peliculaRepository, IMapper mapper) : ControllerBase
     {
         private readonly IMapper _mapper = mapper;

--- a/ApiCurso/Controllers/V2/CategoriasController.cs
+++ b/ApiCurso/Controllers/V2/CategoriasController.cs
@@ -1,0 +1,25 @@
+﻿using ApiCurso.Repository.IRepository;
+using Asp.Versioning;
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ApiCurso.Controllers.V2
+{
+    [Authorize(Roles = "admin")]
+    [Route("api/v{version:apiVersion}/categorias")]
+    [ApiController]
+    [ApiVersion("2.0")]
+    public class CategoriasController(ICategoriaRepository categoriaRepository, IMapper mapper) : ControllerBase
+    {
+        private readonly ICategoriaRepository _categoriaRepository = categoriaRepository;
+        private readonly IMapper _mapper = mapper;
+
+        [AllowAnonymous]
+        [HttpGet("GetString")]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "string1", "string2" };
+        }
+    }
+}

--- a/ApiCurso/Program.cs
+++ b/ApiCurso/Program.cs
@@ -2,6 +2,7 @@ using ApiCurso.Data;
 using ApiCurso.Mapper;
 using ApiCurso.Repository;
 using ApiCurso.Repository.IRepository;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -53,9 +54,43 @@ builder.Services.AddSwaggerGen(options =>
                 In = ParameterLocation.Header
             }, new List<string> { } }
     });
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "Api Curso v1",
+        Version = "v1",
+        Description = "API para el curso de ASP.NET Core Web API con C# y SQL Server",
+        TermsOfService = new Uri("https://example.com/terms"),
+        Contact = new OpenApiContact()
+        {
+            Name = "VazquezCoder",
+            Url = new Uri("https://example.com/contact")
+        },
+        License = new OpenApiLicense()
+        {
+            Name = "Licencia de uso",
+            Url = new Uri("https://example.com/license")
+        }
+    });
+    options.SwaggerDoc("v2", new OpenApiInfo
+    {
+        Title = "Api Curso v2",
+        Version = "v2",
+        Description = "API para el curso de ASP.NET Core Web API con C# y SQL Server",
+        TermsOfService = new Uri("https://example.com/terms"),
+        Contact = new OpenApiContact()
+        {
+            Name = "VazquezCoder",
+            Url = new Uri("https://example.com/contact")
+        },
+        License = new OpenApiLicense()
+        {
+            Name = "Licencia de uso",
+            Url = new Uri("https://example.com/license")
+        }
+    });
 });
 
-//Add repository's
+//Soporte repository's
 builder.Services.AddScoped<ICategoriaRepository, CategoriaRepository>();
 builder.Services.AddScoped<IPeliculaRepository, PeliculaRepository>();
 builder.Services.AddScoped<IUsuarioRepository, UsuarioRepository>();
@@ -79,7 +114,23 @@ builder.Services.AddAuthentication(j =>
     };
 });
 
-//CORS
+//Soporte para versionado de API
+var apiVersioningBuilder = builder.Services.AddApiVersioning(options =>
+{
+    options.AssumeDefaultVersionWhenUnspecified = true;
+    options.DefaultApiVersion = new ApiVersion(1, 0);
+    options.ReportApiVersions = true;
+    //options.ApiVersionReader = ApiVersionReader.Combine(
+    //    new QueryStringApiVersionReader("api-version"));
+});
+
+apiVersioningBuilder.AddApiExplorer(options =>
+{
+    options.GroupNameFormat = "'v'VVV";
+    options.SubstituteApiVersionInUrl = true;
+});
+
+//Soporte CORS
 //Habilitar: 1-Un único dominio, 2- Multiples dominios, 3- Todos los dominios
 //Ejemplo: http://localhost:1234
 //(*) para todos los dominios
@@ -91,7 +142,7 @@ builder.Services.AddCors(builder =>
     });
 });
 
-//Add AutoMapper
+//Soporte AutoMapper
 builder.Services.AddAutoMapper(typeof(PeliculasMapper));
 
 var app = builder.Build();
@@ -100,7 +151,11 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwaggerUI(options =>
+    {
+        options.SwaggerEndpoint("/swagger/v1/swagger.json", "Api Curso v1");
+        options.SwaggerEndpoint("/swagger/v2/swagger.json", "Api Curso v2");
+    });
 }
 
 app.UseHttpsRedirection();


### PR DESCRIPTION
Updated project to support API versioning with new packages. Refactored `CategoriasController` and `PeliculasController` to include versioning in routes and namespaces. Added `ApiVersionNeutral` to `UsuariosController`. Enhanced Swagger documentation for multiple API versions and configured CORS and AutoMapper support. Duplicated controllers for version `2.0` to allow future enhancements.